### PR TITLE
[SWEA 1288] 새로운 불면증 치료법 - 서미영

### DIFF
--- a/SWEA/SWEA_1288/SWEA_1288_seoming.java
+++ b/SWEA/SWEA_1288/SWEA_1288_seoming.java
@@ -1,0 +1,84 @@
+/*
+1. 문제 확인
+- 호석이는 N의 배수 번호인 양을 세기로 함
+   - 즉, 첫 번째에는 N번 양을 세고, 두 번째에는 2N번 양, … , k번째에는 kN번 양을 센다.
+- 각 자리수에서 0에서 9까지의 모든 숫자를 보는 것은 최소 몇 번 양을 센 시점일까?
+
+2. 목표
+- 최소 몇 번 양을 세었을 때 이전에 봤던 숫자들의 자릿수에서 0에서 9까지의 모든 숫자를 보게 되는지 출력한다.
+   - 호석이는 xN번 양을 세고 있다.
+   
+3. 문제에서 언급한 예시 이해하기
+ex) N = 1295
+- 첫 번째로 N = 1295번 양을 센다
+   - 본 숫자: 1, 2, 5, 9
+- 두 번째로 2N = 2590번 양을 센다
+   - 본 숫자: 0, 2, 5, 9
+- 세 번째로 3N = 3885번 양을 센다
+   - 본 숫자: 3, 5, 8
+- 네 번째로 4N = 5180번 양을 센다
+   - 본 숫자: 0, 1, 5, 8
+- 다섯 번째로 5N = 6475번 양을 센다
+   - 본 숫자: 4, 5, 6, 7
+
+=> 다섯 번째까지 살펴봤을 때, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9를 봤다. 
+   즉, 5N번까지 양을 세면 0~9까지 모든 숫자를 보게 되므로 호석이는 양 세기를 멈춘다. 
+=> 정답은 xN = 5*1295 = 6475
+
+4. 알고리즘 접근
+비트마스킹
+*/
+
+import java.util.*;
+import java.io.*;
+
+public class Solution {
+	static StringBuilder sb;
+	static StringTokenizer st;
+	static BufferedReader br;
+	static int N; 
+	static int seen;
+	
+	static final int TARGET = (1 << 10) - 1; // 0~9까지 모두 본 상태
+	
+	public static void main(String[] args) throws Exception {
+		sb = new StringBuilder();
+		br = new BufferedReader(new InputStreamReader(System.in));
+		
+		int T = Integer.parseInt(br.readLine().trim());
+		for (int t=1; t<=T; t++) {
+			N = Integer.parseInt(br.readLine().trim());
+			
+			/*
+			 - seen: 봤던 숫자 기록용 비트마스크
+			    - 맨 처음에는 아직 아무 숫자로 못 봤으니 0으로 저장
+			    - 새로운 숫자를 볼 때마다 해당 위치의 숫자 비트를 1로 바꿔주면 됨
+			 - k: N의 몇 번째 배수인지 
+			    - N, 2N, 3N, 4N, … 이렇게 곱하면서 계속 새로운 숫자가 나오는지 확인하잖아?
+			    - 그때 지금 몇 번째 배수를 보고 있는지 저장 
+			 */
+			seen = 0;
+			int k=0;
+			for (k=1; ; k++) {
+				/*
+				 * - String.valueOf(숫자값): 숫자값을 문자열로 바꿔줌
+				 *    - ex) String.valueOf(5535) --> "5535"
+				 * - .toCharArray(): 문자열 --> 문자 배열(char[])로 변환
+				 *    - ex) {'5', '5', '3', '5'}
+				 */
+				char[] arr = String.valueOf(N*k).toCharArray(); // N*k 값을 문자열로 표현한 것
+				for (char c : arr) {
+					int num = c - '0';  // 문자 --> 숫자
+					seen = seen | (1<<num); // 각 숫자에 대해 등장했다는 의미로 bit를 1로 변경
+				}
+				
+				if (seen == TARGET) {  // 모든 숫자가 등장했다면, 종료
+					break;
+				}
+			}
+			
+			sb.append("#").append(t).append(" ").append(k*N).append("\n");
+		}
+		System.out.println(sb);
+	}
+}


### PR DESCRIPTION
## 📘 언어
- [ ] C++
- [X] JAVA

## ⏱️ 성능
- 메모리: 22,400 KB
- 실행 시간: 74 ms
- 푸는 데 걸린 시간(개인): 60 분
   - 비트마스킹을 이해하는데 시간이 쫌 걸렸다.

---
## 1. 이 문제를 '비트 마스킹' 알고리즘으로 접근할 수 있는 이유는?
사실 이 문제는 0부터 9까지 한번씩 값이 등장하는지를 체크하면 되므로, 굳이 비트마스킹 알고리즘을 안써도 배열로 접근하면 풀 수 있다.

그치만, 이 문제는 비트마스킹으로 문제를 풀기에 최적인 문제이다! 그 이유는?

### 1-1. 요소의 개수가 많지 않은 문제 (보통 20개 이하)
비트마스킹은 각 항목을 비트 하나(0 또는 1)로 저장한다.
그런데 컴퓨터의 정수형 자료는 보통
- `int`: 32비트 (0~31번째 비트 사용)
- `long`: 64비트 (0~63번째 비트 사용)

비트 마스크는 1비트당 1개의 상태를 나타내므로, 
한 정수로 표현 가능한 상태 수는 32비트 또는 64비트다.
👉 즉, **최대 64개 항목까지만** 한 변수로 표현 가능하다.

> **🤨 궁금증**
"왜 근데 보통 20개 이하로 제한한다는거야?"

비트마스킹으로 표현할 수 있는 가능한 상태의 개수는

**각 항목이 0 또는 1, **
즉 2가지 상태를 가지기 때문에 

만약 N개의 항목이 있으면 가능한 조합은
<img src="https://velog.velcdn.com/images/seomiyoung1124/post/e804e636-f4f7-4e15-ac80-b3101bb94718/image.png" width="150px">

예를 들어서 N이 3이라면,
가능한 조합은 다음과 같다.

| N  | 가능한 조합          | 예시                                     |
| -- | --------------- | -------------------------------------- |
| 3  | 2³ = 8          | 000, 001, 010, 011, 100, 101, 110, 111 |

따라서, N에 따른 가능한 상태 수는 다음과 같다.

| N  | 가능한 상태 수(2^N) |
| -- | ------------- | 
| 10 | 1,024         |        
| 15 | 32,768        |
| 20 | 1,048,576     | 
| 25 | 33,554,432    | 
| 30 | 1,073,741,824 |

여기서 보면 N이 커짐에 따라 가능한 상태의 수도 급격히 늘어남을 확인할 수 있다.

#### ✔️ Java 기준 "1초 제한"은 대략 10⁷ ~ 10⁸ 연산
자바는 C++보다 약간 느리기 때문에
안전하게 1초에 약 10⁷번 연산 가능하다고 보는 게 일반적이다.

`1,048,576(N이 20일때)` < `10^7` < `33,554,432(N이 25일때)`

암튼... 이래서
비트마스킹 방법에서 N이 20보다 커지면 시간 복잡도가 감당이 안될수도 있기 때문에 
N이 20개 이하인 경우를 추천하는 것이다!

> 이 문제에서는?

0부터 9까지 값이 등장하냐/안하냐 이렇게 확인하면 되므로
고려 요소가 0~9로, **10개**이다.

충분히 비트마스킹으로 가능하다!

### 1-2. 각 칸에 들어가는 값이 0 또는 1 밖에 없다.
너무나도 이진수로 표현하기 좋은 상황이다.

비트마스킹은 ‘0’과 ‘1’로만 이루어진 데이터를 다루기 때문에,
각 항목이 “있다 / 없다”처럼 두 가지 상태만 가진다면 딱 맞는 도구다.

✔ “선택했는가?”
✔ “방문했는가?”
✔ “봤는가?”
✔ “켜져있는가?”

이런 식으로 참/거짓(boolean) 으로 표현할 수 있는 상황이 비트마스킹에 적합하다.

> 혹시 예전에 `SWEA에서 5215번` 문제를 과제로 풀었던 거 기억하나?

SWEA 5215 “햄버거 다이어트” 문제는
**각 재료(ingredient)**를 넣을까 / 안 넣을까 두 가지로만 나뉘는 상황이었다.
즉, 각 재료의 **“선택 여부”**가 참/거짓(boolean) 으로 표현 가능하기 때문에 비트마스킹이 아주 자연스럽게 들어맞는 구조였다.

그래서 그 문제도 부분집합(넣을까 말까 형식), 비트마스킹 이런식으로 풀었던 기억이 난다. 

---
## 2. 정답 코드 설명
### 2-1. 0~9까지 다 봤을 때의 비트 상태
코드에 
```java
static final int TARGET = (1 << 10) - 1;
```
이렇게 0~9까지 다 봤을 때의 비트 상태(1023)를 고정 상수로 저장해놓은 걸 확인할 수 있다.

여기서 든 궁금증!
왜 저렇게 계산을 할까?
자세히 알아보자.

> 핵심 개념: 비트마스크에서 “숫자 본 상태” 표현

비트마스크에서는 각 **비트(bit)** 가 하나의 **상태(여기선 숫자 0~9)** 를 나타낸다.

* 숫자 0을 봤다 → 0번째 비트를 1로 켠다
* 숫자 1을 봤다 → 1번째 비트를 1로 켠다
* 숫자 9를 봤다 → 9번째 비트를 1로 켠다

| 숫자 | 해당 비트 위치 | 2진수 비트 표현  | 10진수 값 |
| -- | -------- | ---------- | ------ |
| 0  | 1 << 0   | 0000000001 | 1      |
| 1  | 1 << 1   | 0000000010 | 2      |
| 2  | 1 << 2   | 0000000100 | 4      |
| 3  | 1 << 3   | 0000001000 | 8      |
| 4  | 1 << 4   | 0000010000 | 16     |
| 5  | 1 << 5   | 0000100000 | 32     |
| 6  | 1 << 6   | 0001000000 | 64     |
| 7  | 1 << 7   | 0010000000 | 128    |
| 8  | 1 << 8   | 0100000000 | 256    |
| 9  | 1 << 9   | 1000000000 | 512    |

> 그럼 “0~9까지 다 봤다”는 무슨 뜻일까?

0~9번 비트가 전부 켜져 있다 = 이진수로 `1111111111`

> 그런데 왜 `2¹⁰ - 1` 이 되냐?

아 그니깐 우리가 구하고 싶은 값은 `1111111111` 인데, 
`1 << 10` 이게 `10000000000` 이거고 

비트연산에서 `1111111111 + 1 = 10000000000` 이거니깐, 

`1 << 10`에서 `1`을 뺀거다.

\* 참고로 `(1 << 10) - 1` 연산 결과는 2진수 형태로 메모리에 저장된다!

### 2-2. seen - "봤던 숫자 기록용 비트마스크"
```
seen = seen | (1<<num); // 각 숫자에 대해 등장했다는 의미로 bit를 1로 변경
```

예를 들면 이렇게 진행된다.

아래는 N=1692의 **수정된** 단계별 비트 변화이다. 

> N × 1 = 1692 → 숫자: 1, 6, 9, 2

* `1<<1`  → `0000000010`
* `1<<6`  → `0001000000` → OR ⇒ `0001000010`
* `1<<9`  → `1000000000` → OR ⇒ `1001000010`
* `1<<2`  → `0000000100` → OR ⇒ `1001000110`

오키? 이해완료?
