### PR TITLE
[SWEA 10726] 이진수 표현 - 서미영

### DIFF
--- a/SWEA/SWEA_10726/SWEA_10726_seoming.java
+++ b/SWEA/SWEA_10726/SWEA_10726_seoming.java
@@ -1,0 +1,36 @@
+import java.util.*;
+import java.io.*;
+ 
+public class Solution {
+    static BufferedReader br;
+    static StringBuilder sb;
+    static StringTokenizer st;
+     
+    static int N;
+    static int M;
+     
+    public static void main(String[] args) throws Exception {
+        sb = new StringBuilder();
+        br = new BufferedReader(new InputStreamReader(System.in));
+         
+        int T = Integer.parseInt(br.readLine().trim());
+        for (int t=1; t<=T; t++) {
+            st = new StringTokenizer(br.readLine().trim());
+            N = Integer.parseInt(st.nextToken());
+            M = Integer.parseInt(st.nextToken());
+             
+            // <M의 이진수 표현의 마지막 N비트가 모두 1인지 여부 판단하기>
+            int lastNBitsAllOn = (1 << N) - 1; // 하위 N비트가 전부 1인 마스크
+            int lastNBitsFromM = M & lastNBitsAllOn; // M의 하위 N비트만 추출
+             
+            sb.append("#").append(t).append(" ");
+            if (lastNBitsAllOn == lastNBitsFromM) {
+                sb.append("ON").append("\n");
+            }
+            else {
+                sb.append("OFF").append("\n");
+            }
+        }
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 🔗 문제 링크
[SWEA 10726 - 이진수 표현](https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AXRSXf_a9qsDFAXS)

## 📘 언어
- [ ] C++
- [x] JAVA

## ⏱️ 성능
- 메모리: 32,512 KB
- 실행 시간: 116 ms
- 푸는 데 걸린 시간(개인): 40 분

## ✏️ 풀이 아이디어

앞서 풀었던 `[SWEA 1288] 새로운 불면증 치료법`을 먼저 풀면 충분히 쉽게 풀 수 있는 문제다.
혹시 비트마스킹에 대해서 이해가 안간다면, [새로운 불면증 치료법의 PR](https://github.com/Adehanbungukaboja/Adehanbungukaboja/pull/14)을 가면 이해할 수 있을것이다.

앞선 문제도 그렇고,
어쨌든 핵심은

**`(1 << N) - 1`**의 계산은, **`하위 N비트가 전부 1인 비트마스크`**를 만드는 코드라는 점이다.
예를 들면 
- `(1 << 3) - 1` == `111`
- `(1 << 10) - 1` == `1111111111`

> ✔️ **한 줄 정리**
(1 << N) - 1 = 111...1 (1이 N개인 2진수) 
