### PR TITLE
[BOJ 20057] 마법사 상어와 토네이도 - 태선

### DIFF
--- a/BOJ/20057/BOJ_20057_bts.java
+++ b/BOJ/20057/BOJ_20057_bts.java
@@ -1,0 +1,87 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int size;
+    static int[][] map;
+    static int[] dx = {0,1,0,-1};
+    static int[] dy = {-1,0,1,0};
+    static int[][] sandX = {{1,-1,2,-2,1,-1,1,-1,0,0},{-1,-1,0,0,0,0,1,1,2,1},{1,-1,2,-2,1,-1,1,-1,0,0},{1,1,0,0,0,0,-1,-1,-2,-1}};
+    static int[][] sandY = {{1,1,0,0,0,0,-1,-1,-2,-1},{1,-1,2,-2,1,-1,1,-1,0,0},{-1,-1,0,0,0,0,1,1,2,1},{1,-1,2,-2,1,-1,1,-1,0,0}};
+    static double[] ratio = {0.01,0.01,0.02,0.02,0.07,0.07,0.1,0.1,0.05};
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] st;
+        size = Integer.parseInt(br.readLine());
+        map = new int[size][size];
+        for(int i=0;i<size;i++){
+            st = br.readLine().split(" ");
+            for(int j=0;j<size;j++){
+                map[i][j]=Integer.parseInt(st[j]);
+            }
+        }
+        int row = size/2;
+        int col = size/2;
+        int dir=0;
+        int moveSize=1;
+        int sum=0;
+        int sandRow;
+        int sandCol;
+        int restSandRow;
+        int restSandCol;
+        out:
+        while(true){
+            for(int i=0;i<moveSize;i++){
+                row+=dx[dir];
+                col+=dy[dir];
+                int sand = map[row][col];
+                int restSand = sand;
+                map[row][col]=0;
+                for(int d=0;d<9;d++){
+                    sandRow = row+sandX[dir][d];
+                    sandCol = col+sandY[dir][d];
+                    // System.out.println(sandRow+" "+sandCol);
+                    int goneSand = (int)(sand*ratio[d]);
+                    // System.out.println(sand+" "+ratio[d]+" "+goneSand);
+                    if(valid(sandRow,sandCol)){
+                        map[sandRow][sandCol]+=goneSand;
+                    }
+                    else{
+                        sum+=goneSand;
+                    }
+                    restSand-=goneSand;
+                }
+                restSandRow=row+sandX[dir][9];
+                restSandCol=col+sandY[dir][9];
+                if(valid(restSandRow,restSandCol)){
+                    map[restSandRow][restSandCol]+=restSand;
+                }
+                else{
+                    sum+=restSand;
+                }
+                
+                if(row==0&&col==0){
+                    break out;
+                }
+            }
+            if(dir==0){
+                dir++;
+            }
+            else if(dir==1){
+                dir++;
+                moveSize++;
+            }
+            else if(dir==2){
+                dir++;
+            }
+            else{
+                dir=0;
+                moveSize++;
+            }
+        }
+        System.out.println(sum);
+    }
+    static boolean valid(int row, int col){
+        return row>=0&&row<size&&col>=0&&col<size;
+    }
+}


### PR DESCRIPTION
## 🔗 문제 링크
[백준 20057 - 마법사 상어와 토네이도](https://www.acmicpc.net/problem/20057)

## 📘 언어
- [ ] C++
- [x] JAVA

## ⏱️ 성능
- 메모리: 40852 KB
- 실행 시간: 436 ms
- 푸는 데 걸린 시간(개인): 37 분

## ✏️ 풀이 아이디어
- 시작점 설정
격자의 정중앙에서 시작하므로, 시작 좌표는 (size / 2, size / 2)로 잡는다.
이 지점부터 토네이도가 이동하며 모래를 흩뿌리게 된다.

- 이동 규칙 구현
토네이도는 달팽이 모양으로 이동한다.
이동 순서는 다음과 같다:  
왼쪽 1칸 → 아래 1칸 → 오른쪽 2칸 → 위 2칸 → 왼쪽 3칸 → 아래 3칸 → ...  
즉, 왼쪽/오른쪽 이동 후에는 이동 거리(moveSize)가 1 증가한다.
이 규칙을 바탕으로 while문 안에서 dir과 moveSize를 조정하며 이동시킨다.

- 모래 퍼짐 구현(sand spread)
토네이도가 이동할 때, 현재 칸의 모래를 비율에 따라 주변으로 퍼뜨린다.
각 방향(dir)에 따라 모래가 흩어지는 위치가 다르므로,
방향별로 sandX[dir], sandY[dir] 배열을 미리 정의해 둔다.
예를 들어, 서쪽으로 이동할 때의 모래 퍼짐 위치와 남쪽으로 이동할 때의 위치가 다르기 때문이다.  
퍼지는 비율은sandX와 sandY에설정한것처럼
0.01, 0.01, 0.02, 0.02, 0.07, 0.07, 0.1, 0.1, 0.05 순서로 적용한다.

- 격자 밖으로 나가는 모래 처리
모래가 격자 밖으로 나가면 sum 변수에 더해서
최종적으로 격자 밖으로 나간 모래의 총량을 구한다.

- α(알파) 위치 처리
비율 계산 후 남은 모래(restSand)는 α 방향으로 모두 이동한다.
만약 α 위치가 격자 밖이라면, 그 양도 sum에 더한다.

- 종료 조건
토네이도가 (0, 0) 좌표에 도달하면 시뮬레이션을 종료한다.
이때까지 누적된 sum이 곧 정답이 된다.