### PR TITLE
[BOJ 1018] 체스판 다시 칠하기(비트마스킹) - 태선

### DIFF
--- a/BOJ/1018/BOJ_1018_bts.java
+++ b/BOJ/1018/BOJ_1018_bts.java
@@ -1,0 +1,54 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static long[] map;
+    //w는1로 b는 0으로
+    static int wb = 0b10101010;
+    static int bw = 0b01010101;
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] st = br.readLine().split(" ");
+        int maxRow = Integer.parseInt(st[0]);
+        int maxCol = Integer.parseInt(st[1]);
+        map = new long[maxRow];
+        String s;
+        for(int i=0;i<maxRow;i++){
+            s = br.readLine();
+            for(int j=maxCol-1;j>=0;j--){
+                char c = s.charAt(j);
+                if(c=='W'){
+                    //long으로 하려면 1L을 밀어야 오버플로우가 나지않음
+                    map[i]|=(1L<<j);
+                }
+            }
+        }
+        int count;
+        int min=maxRow*maxCol;
+        
+        for(int i=0;i<=maxRow-8;i++){
+            for(int j=0;j<=maxCol-8;j++){
+                count = check(i,j);
+                min = Math.min(min,count);
+            }
+        }
+        System.out.println(min);
+    }
+    static int check(int row, int col){
+        int sum1=0;
+        int sum2=0;
+        for(int i=row;i<row+8;i++){
+            long target = (map[i] >> col) & 0xFFL;//8자까지나오게 255와 and연산
+            if(i%2==0){
+                //8자리의 비트에 ^연산을해서 1의갯수를 세면 다른칸의 갯수가 나옴
+                sum1+=Long.bitCount(target^bw);
+                sum2+=Long.bitCount(target^wb);
+            }
+            else{
+                sum1+=Long.bitCount(target^wb);
+                sum2+=Long.bitCount(target^bw);
+            }
+        }
+        return Math.min(sum1,sum2);
+    }
+}


### PR DESCRIPTION
## 🔗 문제 링크
[백준 1018 - 체스판 다시 칠하기](https://www.acmicpc.net/problem/1018)

## 📘 언어
- [ ] C++
- [x] JAVA

## ⏱️ 성능
- 메모리: 11672 KB
- 실행 시간: 68 ms
- 푸는 데 걸린 시간(개인): 27 분

## ✏️ 풀이 아이디어
원래라면 문자열 비교로 풀 수 있는 문제이지만,
이번에는 비트마스킹을 활용해 효율적으로 풀어보았다.

각 줄을 비트로 변환하여,

B는 0,
W는 1
로 치환한다.

이후 체스판의 기본 패턴 두 가지를

bw 줄: 0b01010101
wb 줄: 0b10101010
로 미리 정의해둔다.

입력받은 각 행(map[i])은 64비트 정수(long)로 저장된다.
이때 (map[i] >> col) & 0xFFL 연산을 수행하면,
현재 위치(col)에서 오른쪽으로 8칸짜리 부분 체스판을 추출할 수 있다.
(>> col로 오른쪽으로 밀어주고, & 0xFFL로 하위 8비트만 남긴다.)

그 후,

Long.bitCount(target ^ bw);

처럼 XOR 연산을 통해 현재 부분 체스판(target)과 이상적인 체스판(bw 혹은 wb)의 차이를 비트 단위로 비교한다.
XOR 결과에서 1이 된 비트의 개수는 곧 다른 색으로 칠해야 하는 칸의 개수이므로,
Long.bitCount()를 이용해 이를 빠르게 계산할 수 있다.

이 과정을 모든 8×8 구간에 대해 수행하면서,
필요한 최소 색칠 횟수를 갱신하면 된다.

결과:
| 현재의 코드 | 과거의 코드 |
|--------------|--------------|
| ![old](https://github.com/user-attachments/assets/5b02c180-4a80-4f4b-b685-a871b0f187c2) | ![new](https://github.com/user-attachments/assets/b37a6408-89c9-432a-9105-e92d569ab994) |
매우 빨라졌다!!

### 🧑‍🏫 이정균님의 평가  
> ![review](https://github.com/user-attachments/assets/1f3f5f0c-34d8-48ad-8f4a-f1389913face)  
