### PR TITLE
[BOJ 14658] 하늘에서 별똥별이 빗발친다 - 김지

### DIFF
--- a/BOJ/14658/BOJ_14658_kimji.cpp
+++ b/BOJ/14658/BOJ_14658_kimji.cpp
@@ -1,0 +1,51 @@
+﻿#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int n, m, l, k;
+vector<pair<int, int>> stars; // 별 좌표 저장
+int ans = -1;
+
+void input() {
+	cin >> n >> m >> l >> k;
+	int x, y;
+	for (int i = 0; i < k; i++) {
+		cin >> x >> y;
+		stars.push_back({ x, y }); // 1-based 좌표 그대로 저장
+	}
+}
+
+void solution() {
+	// 모든 별 좌표를 트램펄린 왼쪽 아래 꼭짓점 후보로 사용
+	for (int i = 0; i < k; i++) {
+		for (int j = 0; j < k; j++) {
+			// 첫번쨰 왼쪽 아래 꼭짓점
+			int x0 = stars[i].first;
+			int y0 = stars[j].second;
+
+			// 이를 기준으로 테두리 포함해서 별이 속하는 지 확인하기 
+			int cnt = 0;
+			for (int s = 0; s < k; s++) {
+				int x = stars[s].first;
+				int y = stars[s].second;
+
+				// 별똥별이 떨어지는 위치는 범위 안에 있기 때문에
+				// 트램펄린 테두리 포함해서 안에만 있으면 됨 
+				if (x0 <= x && x <= x0 + l && y0 <= y && y <= y0 + l)	cnt++;
+			}
+			ans = max(ans, cnt);
+		}
+	}
+}
+
+int main() {
+	ios::sync_with_stdio(0); cin.tie(0);
+
+	input();
+	solution();
+
+	cout << (k - ans); // 트램펄린 밖의 별 개수
+	return 0;
+}


### PR DESCRIPTION
## 🔗 문제 링크
[백준 14658 - 하늘에서 별똥별이 빗발친다](https://www.acmicpc.net/problem/14658)

## 📘 언어
- [x] C++
- [ ] JAVA

## ⏱️ 성능
- 메모리: 2020 KB
- 실행 시간: 4 ms
- 푸는 데 걸린 시간(개인):  50 분

## ✏️ 풀이 아이디어
핵심 접근 방법 요약

사실 처음에 누적합으로 될 줄 알고, 누적합을 했는데, 값이 이상하게 나오더라구요.. 그래서 아니구나라는 것을 깨닫고 다른방식을 고민했습니다.

그래서 저는 모든 코드의 시작은 **완탐**으로부터 시작을 하기로 하고 완탐으로 시작했습니다.
별똥별의 낙하 좌표를 입력받습니다. 그리고 별똥별은 n, m 사이의 위치만 주어지니깐, 트램펄린이 범위를 벗어나든 말든 신경을 쓸 필요가 없었습니다.

문제에서 별똥별은 테두리에 걸칠 수 있다고 했으니깐, 모든 별똥별을 각각 꼭짓점에 있다고 생각을 하고, 그 지점부터 트램펄린의 길이인 x0+l, y0+l을 포함한 범위에 있는 개수를 계산 했습니다.
이 때 x0과 y0은 떨어지는 **낙하 좌표**를 의미하는 것이 아니라, 그냥 별이 떨어지는 좌표들의 모든 조합을 의미 합니다.
즉, 최대한 많은 별들을 포함해야하기 때문에, 떨어지는 부분의 각각의 좌표들을 조합하여 그 지점으로 부터 트램펄린을 전개하는 것입니다.
++++ 여기서 또 의문이 들 수 있는 점은 왜 x0+l, y0+l까지만 보냐고 할 수 있을 것입니다. 이는 x0, y0를 왼쪽 아래 꼭짓점이라고 지정해뒀기 때문에, x0+l, y0+l이 우측상단이 될 것입니다. 이 범위 안에 다른 (x0+l, y0-l), (x0-l, y0+l), (x0-l, y0-l)을 범위는 모두 다 중복되는 범위에 속하게 되기 때문에 좌측하단, 우측상단만으로 트램펄린을 구성하고 계산을 진행한 것입니다!
그림을 그려보면 겹치는 부분이 있다는 생각을 할 수 있을 거에요..!

이렇게 트램펄린을 전개하고, 그 곳에 속하는 별똥별의 개수를 구하고, 최종 정답은 지구에 충돌하는 별똥별의 개수이기 때문에 별똥별 총 개수에서 트램펄린에 속하는 별똥별의 개수를 빼주면 그것이 정답이 됩니다.

이를 통해 알고리즘을 먼저 적용을 해보려는 안좋은 습관을 다시 한번 버려야한다는 것을 깨달아버렸습니다.
